### PR TITLE
A minor change to allow a NULL value

### DIFF
--- a/project/riskofbias/models.py
+++ b/project/riskofbias/models.py
@@ -381,7 +381,9 @@ class RiskOfBias(models.Model):
 class RiskOfBiasMetricAnswers(models.Model):
     metric = models.ForeignKey(
         RiskOfBiasMetric,
-        related_name='answers')
+        related_name='answers',
+        null=True,
+        blank=True)
     answer_choice = models.TextField(
         default = 'Not reported',
         blank=False


### PR DESCRIPTION
This change allows a NULL value in the newly-created answers table's 'metric_id' foreign key field.  This gives the ability to set a group of answers as 'default' answers if they are not related to a specific metric.