### PR TITLE
allow user to click on column headers to sort endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ project/hawc/settings/local.py
 project/static/css/hawc_d3_aggregated.css
 project/celerybeat*
 
+#Vim swapfiles
+*.swp
+*.swo
+
 # folders
 __pycache__
 .idea/*

--- a/project/animal/forms.py
+++ b/project/animal/forms.py
@@ -579,7 +579,10 @@ class EndpointFilterForm(forms.Form):
     
     ORDER_BY_CHOICES = (
         ('animal_group__experiment__study__short_citation', 'study'),
+        ('animal_group__experiment__name', 'experiment name'),
+        ('animal_group__name', 'animal group'),
         ('name', 'endpoint name'),
+        ('animal_group__dosing_regime__doses__dose_units_id', 'dose units'),
         ('system', 'system'),
         ('organ', 'organ'),
         ('effect', 'effect'),

--- a/project/assets/animal/EndpointListTable.js
+++ b/project/assets/animal/EndpointListTable.js
@@ -26,6 +26,15 @@ class EndpointListTable {
             ];
         tbl.setColGroup([12, 16, 17, 31, 10, 7, 7]);
         tbl.addHeaderRow(headers);
+
+        var headersToSortKeys = tbl.makeHeaderToSortKeyMapFromOrderByDropdown("select#id_order_by", {
+            'experiment name': 'experiment',
+            'endpoint name': 'endpoint',
+            'dose units': 'units'
+        });
+
+        tbl.enableSortableHeaderLinks($("#initial_order_by").val(), headersToSortKeys);
+
         this.endpoints.forEach(function(v){
             tbl.addRow(v.build_endpoint_list_row());
         });

--- a/project/assets/epi/OutcomeListTable.js
+++ b/project/assets/epi/OutcomeListTable.js
@@ -14,20 +14,24 @@ class OutcomeListTable {
         }
 
         var x, table = this.table,
-            headerTexts = [
-			    {text:'Study',link:'study_population__study__short_citation'},
-	            {text:'Study population',link:'study_population__name'},
-                {text:'Outcome',link:'name'},
-                {text:'System',link:'system'},
-                {text:'Effect',link:'effect'},
-                {text:'Diagnostic',link:'diagnostic'}
-            ],
-			headers = [];
-		for (x in headerTexts) 
-		    headers.push($('<a href="'+location.origin+location.pathname+'?order_by={0}">'.printf(headerTexts[x].link)).html(headerTexts[x].text));
-        headers.pop();
-		table.setColGroup([12, 25, 16, 17, 10, 13]);
+            headers = [
+                'Study',
+                'Study population',
+                'Outcome',
+                'System',
+                'Effect',
+                'Diagnostic'
+            ];
+
+        table.setColGroup([12, 25, 16, 17, 10, 13]);
         table.addHeaderRow(headers);
+
+        var headersToSortKeys = table.makeHeaderToSortKeyMapFromOrderByDropdown("select#id_order_by", {
+            'outcome name': 'outcome'
+        });
+
+        table.enableSortableHeaderLinks($("#initial_order_by").val(), headersToSortKeys);
+
         this.outcomes.map((outcome) => {
             table.addRow(outcome.buildListRow());
         });

--- a/project/assets/invitro/IVEndpointListTable.js
+++ b/project/assets/invitro/IVEndpointListTable.js
@@ -26,6 +26,15 @@ class IVEndpointListTable {
             ];
         table.setColGroup([10, 16, 12, 11, 16, 20, 7, 7]);
         table.addHeaderRow(headers);
+
+        var headersToSortKeys = table.makeHeaderToSortKeyMapFromOrderByDropdown("select#id_order_by", {
+            'experiment name': 'experiment',
+            'endpoint name': 'endpoint',
+            'effect': 'effect category'
+        });
+
+        table.enableSortableHeaderLinks($("#initial_order_by").val(), headersToSortKeys, { unsortableColumns: [ 'effects' ] });
+
         this.endpoints.map((endpoint) => {
             table.addRow(endpoint.buildListRow());
         });

--- a/project/assets/utils/BaseTable.js
+++ b/project/assets/utils/BaseTable.js
@@ -69,6 +69,56 @@ class BaseTable {
         if (txt.length>0)
             this.tfoot.html('<tr><td colspan="{0}">{1}</td></tr>'.printf(colspan, txt));
     }
+
+    // assumes all column headers are unique, ignoring case
+    makeHeaderToSortKeyMapFromOrderByDropdown(orderByDropdownSelector, overrides) {
+        var headersToSortKeys = {};
+
+        $(orderByDropdownSelector).find("option").each(function() {
+            var currOption = $(this);
+
+            var optionText = currOption.text().toLowerCase();
+            if (optionText in overrides) {
+                optionText = overrides[optionText];
+            }
+            headersToSortKeys[optionText] = currOption.val();
+        });
+
+        return headersToSortKeys;
+    }
+
+    enableSortableHeaderLinks(currentActiveSort, headersToSortKeys, options = {}) {
+        this.thead.find('th').each(function() {
+            var currHeaderCell = $(this);
+            var currHeaderText = currHeaderCell.html();
+            var sortKey = headersToSortKeys[currHeaderText.toLowerCase()];
+
+            if (sortKey !== undefined) {
+                currHeaderCell.addClass("sort-header");
+
+                if (sortKey == currentActiveSort) {
+                    currHeaderCell.addClass("active-sort").addClass("sort-" + (currentActiveSort.startsWith("-") ? "up" : "down"));
+                } else {
+                    if (sortKey.startsWith("-")) {
+                        currHeaderCell.addClass("potential-sort-down");
+                    }
+
+                    var clickableLink = $("<a/>").attr("href", "?order_by=" + sortKey).html(currHeaderText);
+                    $(this).empty().append(clickableLink);
+                }
+            } else {
+                var warnAboutMissingMapping = true;
+
+                if (options.unsortableColumns !== undefined && options.unsortableColumns.indexOf(currHeaderText.toLowerCase()) != -1) {
+                    warnAboutMissingMapping = false;
+                }
+
+                if (warnAboutMissingMapping) {
+                    console.log("warning - sort key for header '" + currHeaderText + "' not found in mapping");
+                }
+            }
+        });
+    }
 }
 
 export default BaseTable;

--- a/project/invitro/forms.py
+++ b/project/invitro/forms.py
@@ -340,12 +340,15 @@ class IVEndpointFilterForm(forms.Form):
 
     ORDER_BY_CHOICES = (
         ('experiment__study__short_citation', 'study'),
+        ('experiment__name', 'experiment name'),
         ('name', 'endpoint name'),
         ('assay_type', 'assay type'),
         ('effect', 'effect'),
         ('chemical__name', 'chemical'),
         ('category__name', 'category'),
         ('observation_time', 'observation time'),
+        ('experiment__dose_units_id', 'dose units'),
+        ('response_units', 'response units'),
     )
 
     studies = selectable.AutoCompleteSelectMultipleField(

--- a/project/static/css/hawc.css
+++ b/project/static/css/hawc.css
@@ -477,6 +477,21 @@ table th.sort-up:after {
   }
 
 
+/* custom additions for server-side order_by functionality, initially implemented for endpoint listings */
+table th.sort-header.active-sort {
+  cursor:default;
+}
+
+table th.sort-header.potential-sort-down:after {
+  border-bottom:none;
+  border-width:4px 4px 0;
+}
+
+table th.sort-header a {
+  color: black;
+  text-decoration: none;
+}
+
 /*
 Print styling
 */

--- a/project/templates/animal/endpoint_list.html
+++ b/project/templates/animal/endpoint_list.html
@@ -54,6 +54,10 @@
                                 <span class='help-inline'>{{field.help_text}}</span>
                             </div>
                             {{field.errors|add_class:"alert alert-error"}}
+
+                            {% if field.name == "order_by" and field.value is not None %}
+                            <input type="hidden" id="initial_order_by" value="{{ field.value }}"/>
+                            {% endif %}
                         </div>
 
                         {% if forloop.counter0|add:1|divisibleby:4 %}

--- a/project/templates/epi/outcome_list.html
+++ b/project/templates/epi/outcome_list.html
@@ -40,6 +40,10 @@
                                 <span class='help-inline'>{{field.help_text}}</span>
                             </div>
                             {{field.errors|add_class:"alert alert-error"}}
+
+                            {% if field.name == "order_by" and field.value is not None %}
+                            <input type="hidden" id="initial_order_by" value="{{ field.value }}"/>
+                            {% endif %}
                         </div>
 
                         {% if forloop.counter0|add:1|divisibleby:4 %}

--- a/project/templates/invitro/ivendpoint_list.html
+++ b/project/templates/invitro/ivendpoint_list.html
@@ -42,6 +42,10 @@
                                 <span class='help-inline'>{{field.help_text}}</span>
                             </div>
                             {{field.errors|add_class:"alert alert-error"}}
+
+                            {% if field.name == "order_by" and field.value is not None %}
+                            <input type="hidden" id="initial_order_by" value="{{ field.value }}"/>
+                            {% endif %}
                         </div>
 
                         {% if forloop.counter0|add:1|divisibleby:4 %}


### PR DESCRIPTION
This adds clickable headers to various endpoint listings. Current sorted column is not a link, the others are. Up/down arrow indicators to show sort direction. You can only sort in one direction per column, basically whatever is defined in forms.py for a given project.

I am just hooking into the existing sorting, which occasionally seems wonky. As an example, see https://hawcprd.epa.gov/ani/assessment/100000039/endpoints/ and order by LOAEL - the results are all over the place. I didn't dig into this, seems outside the scope of the ticket, but I can if you'd like.

I didn't have any epi meta endpoints to check against, which is why I didn't add it there. This would be the epimeta_metaresult db table, yes? 0 rows in the db dump that I've got. I can add this to epimeta too if you can point me towards an example with some data in it.

Finally, took a best guess at how to name branches, going with company name and the card # in Trello. Happy to change this if you'd prefer another format.

----- Commit message below -----

See https://trello.com/c/GNAHdqpw/15-endpoint-list-in-addition-to-the-order-by-field-is-it-possible-to-let-the-user-click-on-the-column-header-to-sort-eg-study-expe

This includes animal endpoints, invitro endpoints, and epi outcomes. Does not include epi meta. Essentially
this commit just adds some shortcut links to the headers.

Basic conversion approach for each type of outcome:
1. add column names/sortkeys to relevant Django forms.py file, if needed
2. add a hidden field to the form template to store the passed in order_by value
3. add entry to the JS that sets up the table to establish mapping between column names and sort keys

(and as a one time, modify BaseTable.js with some utility functions, add some new css, etc.)

Note that epi outcomes already had sorting. For consistency's sake, that's been replaced with this
new approach which includes things like a sort indicator on the column.