### PR TITLE
Icf 55 update epi form instructions

### DIFF
--- a/project/static/css/hawc.css
+++ b/project/static/css/hawc.css
@@ -506,3 +506,18 @@ Risk of Bias
     font-weight: bold;
     color: darkgreen;
 }
+
+.help-block .help-text-notes {
+	display: block;
+	font-style: italic;
+}
+
+.help-block .important-note {
+	display: block;
+	font-style: italic;
+	color: red;
+}
+
+.help-block .optional {
+	color: #999999;
+}

--- a/project/templates/epi/comparisonset_form.html
+++ b/project/templates/epi/comparisonset_form.html
@@ -29,14 +29,9 @@
     </legend>
     {% if crud == "Create" %}
       <p class="help-block">
-        Groups are associated with each group-collection. The total number of individuals in all groups should equal the total number of individuals in the group-collection.
-      </p>
-      <p class="help-block">
-
-        For cohort-base studies groups, may be exposure measurements. For example, exposure-group descriptions may be "quartile 1 (≤1.0)", "quartile 2 (1.0-2.5)", etc.
-      </p>
-      <p class="help-block">
-        For case-controls studies, groups may be based on "cases" and "controls", or similar descriptions of different comparable sample populations.
+		If exposure is a continuous variable, create one group, “Continuous”, for the comparison set. If categorical, create the appropriate number of groups, “Q1”, “Q2”, etc. For case-controls studies, also indicate "Cases" and "Controls". Ex. Continuous; Control T1
+		<span class='help-text-notes'>The total number of individuals in all groups should equal the total number of individuals in the comparison set</span>
+		<span class='important-note'>This field is commonly used in HAWC visualizations.</span>
       </p>
     {% endif %}
     {% include "hawc/_formset_table_template.html" with showDeleteRow=True %}

--- a/project/templates/epi/result_form.html
+++ b/project/templates/epi/result_form.html
@@ -93,8 +93,8 @@
       }).trigger('change');
 
       // change header-text based on result fields
-      var thEst = $("th:contains('Estimate')"),
-          thVar = $("th:contains('Variance')");
+      var thEst = $("th:contains('Estimate') span"),
+          thVar = $("th:contains('Variance') span");
 
       $('#id_estimate_type').change(function(e){
         var txt = (e.target.value === "0")

--- a/project/utils/forms.py
+++ b/project/utils/forms.py
@@ -82,6 +82,20 @@ class BaseFormHelper(cf.FormHelper):
             self.layout.index(firstField),
             cfl.HTML("""<h4>{0}</h4>""".format(text)))
 
+    def find_layout_idx_for_field_name(self, searchName):
+        layoutIdx = 0
+        for layoutElement in self.layout:
+            if isinstance(layoutElement, cfl.LayoutObject):
+                for fieldName in layoutElement.get_field_names():
+                    if isinstance(fieldName, list) and len(fieldName) > 1:
+                        if fieldName[1] == searchName:
+                            return layoutIdx
+            elif isinstance(layoutElement, str):
+                if layoutElement == searchName:
+                    return layoutIdx
+            layoutIdx += 1
+        return None
+
 
 class CopyAsNewSelectorForm(forms.Form):
     label = None


### PR DESCRIPTION
branch with updated instructions. Couple of notes from the Word doc attached https://trello.com/c/ukgqDg0Y/55-change-instructions-on-several-hawc-epi-forms:

1. "Country" on page 2 and "Estimate" on page 7 reference changing some fields from single to multi association. I think that's outside the scope of this ticket so I did not modify that aspect of the model.

2. some of the fields (ex Section 3 "Comparison Set" has Groups fields like name, numerical value, ethnicities, etc.; Section 5 "Result" has Groups fields like n, estimate, variance, etc.) appear in tables. These were already sort of set up with instructions as hover tooltips on the column headers. So for those I updated the text and fixed some issues to get the tooltips working a little better, but I did not make them permanently displayed instructions. One consequence here is that we lose clickable links and the red/italic/bold formatting on some of these. I could look into making the tooltips html-ified; reason I didn't is b/c it looks like that code is used elsewhere and I was leery of making a change like that which can introduce xss vulnerabilities without fully understanding everywhere it's being used. Or, I can modify those to always display the help text below the column header or something instead of as a tooltip. Basically take a look and if you want me to move further in one direction let me know.