### PR TITLE
add study short citation to epi/animal/invitro bulk cleaning interfaces

### DIFF
--- a/project/animal/serializers.py
+++ b/project/animal/serializers.py
@@ -145,35 +145,48 @@ class EndpointSerializer(serializers.ModelSerializer):
 
 
 class ExperimentCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    study_short_citation = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Experiment
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
 
+    def get_study_short_citation(self, obj):
+        return obj.study.short_citation
 
 class AnimalGroupCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    study_short_citation = serializers.SerializerMethodField()
 
     class Meta:
         model = models.AnimalGroup
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
 
+    def get_study_short_citation(self, obj):
+        return obj.experiment.study.short_citation
 
 class EndpointCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
-
+    study_short_citation = serializers.SerializerMethodField()
+    
     class Meta:
         model = models.Endpoint
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
+
+    def get_study_short_citation(self, obj):
+        return obj.animal_group.experiment.study.short_citation
 
 
 class DosingRegimeCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    study_short_citation = serializers.SerializerMethodField()
 
     class Meta:
         model = models.DosingRegime
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
 
+    def get_study_short_citation(self, obj):
+        return obj.dosed_animals.experiment.study.short_citation
 
 SerializerHelper.add_serializer(models.Endpoint, EndpointSerializer)

--- a/project/epi/serializers.py
+++ b/project/epi/serializers.py
@@ -213,26 +213,37 @@ class ComparisonSetSerializer(serializers.ModelSerializer):
 
 
 class OutcomeCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    study_short_citation = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Outcome
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
 
+    def get_study_short_citation(self, obj):
+        return obj.study_population.study.short_citation
 
 class StudyPopulationCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    study_short_citation = serializers.SerializerMethodField()
 
     class Meta:
         model = models.StudyPopulation
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
+
+    def get_study_short_citation(self, obj):
+        return obj.study.short_citation
 
 
 class ExposureCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    study_short_citation = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Exposure
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
+
+    def get_study_short_citation(self, obj):
+        return obj.study_population.study.short_citation
 
 SerializerHelper.add_serializer(models.Outcome, OutcomeSerializer)

--- a/project/invitro/serializers.py
+++ b/project/invitro/serializers.py
@@ -147,19 +147,25 @@ class IVExperimentSerializerFull(IVExperimentSerializer):
 
 
 class IVEndpointCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    study_short_citation = serializers.SerializerMethodField()
 
     class Meta:
         model = models.IVEndpoint
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
 
+    def get_study_short_citation(self, obj):
+        return obj.experiment.study.short_citation
 
 class IVChemicalCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    study_short_citation = serializers.SerializerMethodField()
 
     class Meta:
         model = models.IVChemical
-        cleanup_fields = model.TEXT_CLEANUP_FIELDS
+        cleanup_fields = ('study_short_citation',) + model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
 
+    def get_study_short_citation(self, obj):
+        return obj.study.short_citation
 
 SerializerHelper.add_serializer(models.IVEndpoint, IVEndpointSerializer)


### PR DESCRIPTION
See https://trello.com/c/eB81wYux/17-for-clean-extracted-data-can-you-add-the-study-name-to-the-expanded-fields-it-is-not-possible-right-now-to-determine-what-data

basic approach for each Serializer (e.g. StudyPopulationCleanupFieldsSerializer):
1. add a new SerializerMethodField called "study_short_citation"
2. add this field to "cleanup_fields" / "fields"
3. define a method that grabs this through whatever object chain is needed for the type in question

(just adding directly to TEXT_CLEANUP_FIELDS on the model doesn't work, as that would then become a selectable field to clean; we just want to display it)

Preferred approach would be to just access foreign key field names ORM style, like "experiment__study__short_citation"
but I could not figure out an approach to make that work.

Also looked into an approach using a mixin that could define the #3 method and just delegate it to an
appropriate method on the model class. But I was unable to get this approach to work either, likely
because I don't fully understand Django's rest_framework inner workings.