### PR TITLE
Icf 63 animal bioassay form updates

### DIFF
--- a/project/animal/forms.py
+++ b/project/animal/forms.py
@@ -158,6 +158,7 @@ class AnimalGroupForm(ModelForm):
         if parent:
             self.instance.experiment = parent
 
+        """
         self.fields['lifestage_exposed'].widget = selectable.AutoCompleteWidget(
             lookup_class=lookups.RelatedAnimalGroupLifestageExposedLookup,
             allow_new=True)
@@ -169,6 +170,25 @@ class AnimalGroupForm(ModelForm):
             allow_new=True)
         self.fields['lifestage_assessed'].widget.update_query_parameters(
             {'related': self.instance.experiment.study.assessment.id})
+        """
+
+        # for lifestage assessed/exposed, use a select widget. Manually add in
+        # previously saved values that don't conform to the LIFESTAGE_CHOICES tuple
+        lifestage_dict = dict(models.AnimalGroup.LIFESTAGE_CHOICES)
+
+        if self.instance.lifestage_exposed in lifestage_dict:
+            le_choices = models.AnimalGroup.LIFESTAGE_CHOICES
+        else:
+            le_choices = ((self.instance.lifestage_exposed, self.instance.lifestage_exposed),) + models.AnimalGroup.LIFESTAGE_CHOICES
+        self.fields['lifestage_exposed'].widget = forms.Select(choices=le_choices)
+
+        if self.instance.lifestage_assessed in lifestage_dict:
+            la_choices = models.AnimalGroup.LIFESTAGE_CHOICES
+        else:
+            la_choices = ((self.instance.lifestage_assessed, self.instance.lifestage_assessed),) + models.AnimalGroup.LIFESTAGE_CHOICES
+        self.fields['lifestage_assessed'].widget = forms.Select(choices=la_choices)
+
+
 
         self.fields['siblings'].queryset = models.AnimalGroup.objects.filter(
                 experiment=self.instance.experiment)

--- a/project/animal/forms.py
+++ b/project/animal/forms.py
@@ -147,6 +147,9 @@ class AnimalGroupForm(ModelForm):
     class Meta:
         model = models.AnimalGroup
         exclude = ('experiment', 'dosing_regime', 'generation', 'parents')
+        labels = {
+            'lifestage_assessed': 'Lifestage at assessment'
+        }
 
     def __init__(self, *args, **kwargs):
         parent = kwargs.pop('parent', None)
@@ -239,6 +242,9 @@ class GenerationalAnimalGroupForm(AnimalGroupForm):
     class Meta:
         model = models.AnimalGroup
         exclude = ('experiment', )
+        labels = {
+            'lifestage_assessed': 'Lifestage at assessment'
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/project/animal/models.py
+++ b/project/animal/models.py
@@ -307,8 +307,13 @@ class AnimalGroup(models.Model):
     lifestage_assessed = models.CharField(
         max_length=32,
         blank=True,
-        help_text='Textual life-stage description when endpoints were measured '
-                  '(examples include: "parental, PND18, juvenile, adult, multiple")')
+        help_text='Definitions: <b>Developmental</b>: Prenatal and perinatal exposure in dams or ' +
+                    'postnatal exposure in offspring until sexual maturity (~6 weeks in rats and ' +
+                    'mice). Include studies with pre-mating exposure if the endpoint focus is ' +
+                    'developmental. <b>Adult</b>: Exposure in sexually mature males or females. <b>Adult ' +
+                    '(gestation)</b>: Exposure in dams during pregnancy. <b>Multi-lifestage</b>: includes both ' +
+                    'developmental and adult (i.e., multi-generational studies, exposure that start ' +
+                    'before sexual maturity and continue to adulthood)')
     duration_observation = models.FloatField(
         verbose_name="Exposure-outcome duration",
         help_text='Numeric length of time between start of exposure and outcome assessment, '

--- a/project/animal/models.py
+++ b/project/animal/models.py
@@ -262,6 +262,19 @@ class AnimalGroup(models.Model):
         ("F4", "Fourth-generation (F4)"),
         ("Ot", "Other"))
 
+    # these choices for lifesage expose/assessed were added ~Sept 2018. B/c there
+    # are existing values in the database, we are not going to enforce these choices on
+    # the model as we do for say sex/SEX_CHOICES. Instead we'll leave the model as is,
+    # and start using this to drive a Select widget on the form. For old/existing data,
+    # we'll add the previously saved value to the dropdown at runtime so we don't lose data.
+    LIFESTAGE_CHOICES = (
+        ("Developmental", "Developmental"),
+        ("Adult", "Adult"),
+        ("Adult (gestation)", "Adult (gestation)"),
+        ("Multi-lifestage", "Multi-lifestage")
+    )
+        
+
     TEXT_CLEANUP_FIELDS = (
         'name',
         'animal_source',

--- a/project/animal/models.py
+++ b/project/animal/models.py
@@ -296,7 +296,9 @@ class AnimalGroup(models.Model):
     species = models.ForeignKey(
         'assessment.Species')
     strain = models.ForeignKey(
-        'assessment.Strain')
+        'assessment.Strain',
+        help_text='When adding a new strain, put the stock in parenthesis, e.g., ' +
+                    '\"Sprague-Dawley (Harlan).\"')
     sex = models.CharField(
         max_length=1,
         choices=SEX_CHOICES)
@@ -329,10 +331,8 @@ class AnimalGroup(models.Model):
                     'before sexual maturity and continue to adulthood)')
     duration_observation = models.FloatField(
         verbose_name="Exposure-outcome duration",
-        help_text='Numeric length of time between start of exposure and outcome assessment, '
-                    'in days when &lt;7 (e.g., 5 days), weeks when &ge;7 days to 12 weeks (e.g., 1 '
-                    'week, 12 weeks), or months when &gt;12 weeks (e.g., 15 months). For '
-                    'repeated measures use descriptions such as "1, 2 and 3 weeks"',
+        help_text='Optional: Numeric length of time between start of exposure and outcome assessment in days. ' +
+                    'This field may be used to sort studies which is why days are used as a common metric.',
         blank=True,
         null=True)
     siblings = models.ForeignKey(
@@ -357,7 +357,7 @@ class AnimalGroup(models.Model):
         null=True)  # not enforced in db, but enforced in views
     comments = models.TextField(
         blank=True,
-        verbose_name="Animal Husbandry",
+        verbose_name="Animal Source and Husbandry",
         help_text="Copy paste animal husbandry information from materials and methods, "
                     "use quotation marks around all text directly copy/pasted from paper.")
     created = models.DateTimeField(

--- a/project/animal/models.py
+++ b/project/animal/models.py
@@ -40,8 +40,8 @@ class Experiment(models.Model):
         ("NR", "Not-reported"))
 
     LITTER_EFFECT_CHOICES = (
-        ("NA", "Not-applicable"),
-        ("NR", "Not-reported"),
+        ("NA", "Not applicable"),
+        ("NR", "Not reported"),
         ("YS", "Yes, statistical control"),
         ("YD", "Yes, study-design"),
         ("N",  "No"),
@@ -110,33 +110,33 @@ class Experiment(models.Model):
     vehicle = models.CharField(
         max_length=64,
         verbose_name="Chemical vehicle",
-        help_text="Describe vehicle (use name as described in methods "
-                    "but also add the common name if the vehicle was "
-                    "described in a non-standard way)",
+        help_text="Describe vehicle (use name as described in methods but also add the " +
+                    "common name if the vehicle was described in a non-standard way). " +
+                    "Enter \"not reported\" if the vehicle is not described. For inhalation " +
+                    "studies, air can be inferred if not explicitly reported. " +
+                    "Examples: \"corn oil,\" \"filtered air,\" \"not reported, but assumed clean air.\"",
         blank=True)
     diet = models.TextField(
-        help_text="Copy paste diet/water from materials and methods, "
-                    "use quotation marks around all text directly copy/pasted "
-                    "from paper. If diet is of particular importance in an "
-                    "assessment, then use a short description so it can be "
-                    "displayed in visualizations (e.g., soy-protein free 2020X "
-                    "Teklad). In these cases, the longer materials and methods "
-                    "description can be captured in 'animal husbandry' in the "
-                    "Animal Group extraction module.",
+        help_text="Describe diet as presented in the paper (e.g., \"soy-protein free " +
+                    "2020X Teklad,\" \"Atromin 1310\", \"standard rodent chow\").",
         blank=True)
     guideline_compliance = models.CharField(
         max_length=128,
         blank=True,
-        help_text="""Description of any compliance methods used (i.e. use of EPA 
-                    OECD, NTP, or other guidelines; conducted under GLP guideline 
-                    conditions, non-GLP but consistent with guideline study, 
-                    etc.). This field response should match any description used 
-                    in study evaluation in the reporting quality domain.""")
+        help_text="""Description of any compliance methods used (i.e. use of EPA
+                    OECD, NTP, or other guidelines; conducted under GLP guideline
+                    conditions, non-GLP but consistent with guideline study,
+                    etc.). This field response should match any description used
+                    in study evaluation in the reporting quality domain, e.g., 
+                    GLP study (OECD guidelines 414 and 412, 1981 versions)""")
     litter_effects = models.CharField(
         max_length=2,
         choices=LITTER_EFFECT_CHOICES,
         default="NA",
-        help_text="Type of controls used for litter-effects")
+        help_text="Type of controls used for litter-effects. The \"No\" response " +
+                "will be infrequently used. More typically the information will be " +
+                "\"Not reported\" and assumed not considered. Only use \"No\" if it " +
+                "is explicitly mentioned in the study that litter was not controlled for.")
     litter_effect_notes = models.CharField(
         max_length=128,
         help_text="Any additional notes describing how litter effects were controlled",

--- a/project/assessment/forms.py
+++ b/project/assessment/forms.py
@@ -166,9 +166,6 @@ class StrainForm(forms.ModelForm):
         kwargs.pop('parent', None)
         super().__init__(*args, **kwargs)
 
-    def clean_name(self):
-        return self.cleaned_data['name'].title()
-
 
 class DoseUnitsForm(forms.ModelForm):
 

--- a/project/assets/study/Study.js
+++ b/project/assets/study/Study.js
@@ -126,7 +126,7 @@ class Study{
         tbl.add_tbody_tr('Study identifier', this.data.study_identifier);
         tbl.add_tbody_tr('Author contacted?', HAWCUtils.booleanCheckbox(this.data.contact_author));
         tbl.add_tbody_tr('Author contact details', this.data.ask_author);
-        tbl.add_tbody_tr('Summary and/or extraction comments', this.data.summary);
+        tbl.add_tbody_tr('Extraction comments', this.data.summary);
         $(div).html(tbl.get_tbl());
     }
 

--- a/project/assets/utils/HAWCUtils.js
+++ b/project/assets/utils/HAWCUtils.js
@@ -5,6 +5,8 @@ import d3 from 'd3';
 
 class HAWCUtils {
 
+    static HAWC_NEW_WINDOW_POPUP_CLOSING = "hawcNewWindowPopupClosing";
+
     static booleanCheckbox(value){
         return (value) ? `<i class="fa fa-check"><span class="invisible">${value}</span></i>`:
             `<i class="fa fa-minus"><span class="invisible">${value}</span></i>`;
@@ -15,6 +17,13 @@ class HAWCUtils {
         var href = triggeringLink.href + '?_popup=1';
         var win = window.open(href, '_blank', 'height=500,width=980,resizable=yes,scrollbars=yes');
         win.focus();
+
+        win.onbeforeunload = function(e) {
+            let event = new CustomEvent(window.app.utils.HAWCUtils.HAWC_NEW_WINDOW_POPUP_CLOSING, { detail: { } });
+            triggeringLink.dispatchEvent(event);
+            // interested listeners can access fields in detail e.g. "customField" via e.originalEvent.detail.customField
+        }
+
         return false;
     }
 

--- a/project/lit/models.py
+++ b/project/lit/models.py
@@ -611,7 +611,7 @@ class Reference(models.Model):
     full_text_url = CustomURLField(
         blank=True,
         help_text="Link to full-text URL from journal site (may require increased "
-                  "access privileges, only reviewers and team-members)")
+                  "access privileges to view)")
     created = models.DateTimeField(
         auto_now_add=True)
     last_updated = models.DateTimeField(

--- a/project/study/models.py
+++ b/project/study/models.py
@@ -69,8 +69,8 @@ class Study(Reference):
         max_length=256,
         help_text="How the study should be identified in HAWC (last name year, HERO ID). "
                   "This field is used to select studies for figures and endpoint filters within HAWC, "
-                  "so you may need to add distinguishing features such as chemical name. "
-                  "This field is commonly used in HAWC visualizations.")
+                  "so you may need to add distinguishing features such as chemical name when the assessment "
+                  "includes multiple chemicals. This field may be used in HAWC visualizations.")
     full_citation = models.TextField(
         help_text="Complete study citation, in desired format. First author last name, Initial; "
                   "Second author last name, Initial; etc. (Year). Title. Journal volume (issue): "
@@ -88,21 +88,23 @@ class Study(Reference):
                   "Provide details when a COI is inferred.")
     funding_source = models.TextField(
         blank=True,
-        help_text="When available, cut and paste the funding source information with quotations.")
+        help_text="When reported, cut and paste the funding source information with quotations, e.g., " +
+                    "\"The study was sponsored by Hoechst AG and Dow Europe\".")
     study_identifier = models.CharField(
         max_length=128,
         blank=True,
         verbose_name="Internal study identifier",
-        help_text="HERO LitCiter reference format {First author last name, year, HERO ID} "
-                  "*This field is used for HERO reference formatting purposes to help document preparation.")
+        help_text="This field may be used in HAWC visualizations when there is a preference not to " +
+                    "display the HERO ID number, so use author year format, e.g., Smith, 1978, " +
+                    "Smith and Jones, 1978 or Smith et al (for more than 3 authors)")
     contact_author = models.BooleanField(
         default=False,
         help_text="Was the author contacted for clarification of methods, results, or to request additional data?")
     ask_author = models.TextField(
         blank=True,
         verbose_name="Correspondence details",
-        help_text="Details on correspondence between data-extractor and author, if needed. "
-                  "Please include data and details of the correspondence. The files documenting "
+        help_text="Details on correspondence between data-extractor and author (if author contacted). "
+                  "Please include date and details of the correspondence. The files documenting "
                   "the correspondence can also be added to HAWC as attachments and HERO as a "
                   "new record, but first it is important to redact confidential or personal "
                   "information (e.g., email address).")

--- a/project/templates/animal/animalgroup_form.html
+++ b/project/templates/animal/animalgroup_form.html
@@ -51,9 +51,10 @@
 {% block extrajs %}
 {{form.media}}
 <script type="text/javascript">
+
 $(document).ready(function() {
     var animalGroupSetup = function(){
-            var onSpeciesChange = function(){
+            var onSpeciesChange = function(e, onStrainUpdateComplete){
                 // only show proper strains for a given species
                 var selected = $('#id_strain option:selected').val(),
                     update_strain_opts = function(d){
@@ -64,6 +65,10 @@ $(document).ready(function() {
                         $('#id_strain').html(opts);
                         $('#id_strain option[value="{0}"]'.printf(selected))
                             .prop('selected', true);
+
+                        if (onStrainUpdateComplete !== undefined) {
+                            onStrainUpdateComplete();
+                        }
                     }
                 $.get(
                     '{% url "assessment:get_strains" %}',
@@ -77,6 +82,29 @@ $(document).ready(function() {
             $('#id_species')
                 .change(onSpeciesChange)
                 .trigger('change');
+
+            // refresh species after "Add new strain" popup closes. Wait half a second
+            // to give the addition, if any, time to register.
+            $("a[title='Add new strain']").on(window.app.utils.HAWCUtils.HAWC_NEW_WINDOW_POPUP_CLOSING, function(e) {
+                setTimeout(function() {
+                    var numStrainsBefore = $("#id_strain option").length;
+
+                    // reload the species
+                    onSpeciesChange(null, function() {
+                        var strains = $("#id_strain option");
+
+                        if (strains.length > numStrainsBefore) {
+                            // a new one was added; let's select it.
+                            var highestId = -1;
+                            strains.each(function() {
+                                highestId = Math.max(Number($(this).val()), highestId);
+                            });
+
+                            $("#id_strain").val(highestId);
+                        }
+                    });
+                }, 500);
+            });
         },
         dosingRegimeSetup = function(){
             var drc = $('#dosingRegimeContainer'),


### PR DESCRIPTION
Couple of things to note here:
Animal Bioassay Experiment Module - Short citation: I assume this is referring to the "Guideline compliance" field?

Animal Group Module - lifestage dropdown: since there are existing values for this field outside of the four listed, I handled this by just making the dropdown for the widget, not enforcing at model level. And for those existing other values, I manually add that value to the other 4 in the dropdown, so existing data is ok.

Animal Group Module - strain capitals: I made this change for ones going forward. Deleting/changing the existing values I think is outside the scope of this ticket (and I don't have live db access anyway), so I didn't make those tweaks.

Animal Group Module - strain adding: I added some JS to listen for the "Add a strain" dialog to close, and then reload the list and select the newly added option. I put this at 500ms delay, not sure if that will work in production or not, so that's worth checking on specifically.