### PR TITLE
Icf 96 bulk reference tagging

### DIFF
--- a/project/assets/lit/BulkTagInterface.js
+++ b/project/assets/lit/BulkTagInterface.js
@@ -4,7 +4,7 @@ class BulkTagInterface {
 	assessmentId = -1;
 	pageNum = 0;
 	pageSize = 50;
-	sortOrder = "-year";
+	sortOrder = "authors";
 	referenceSelections = null;
 	tagSelections = null;
 

--- a/project/assets/lit/BulkTagInterface.js
+++ b/project/assets/lit/BulkTagInterface.js
@@ -50,7 +50,6 @@ class BulkTagInterface {
         $('#taglist').html(window.tagtree.get_nested_list({"show_refs_count": false}))
             .on('hawc-tagClicked', function(e){
                 var clickedTag = $(e.target);
-                console.log("tag clicked");
                 var tagId = clickedTag.parent("div").attr("data-id");
                   // $(e.target).addClass("selected");
                 if (clickedTag.hasClass("selected")) {
@@ -63,7 +62,6 @@ class BulkTagInterface {
 					hook.tagSelections.ids[tagId] = true;
                 }
 
-				console.log(hook.tagSelections);
 				hook.updateTaglistTitle();
             });
 
@@ -88,7 +86,6 @@ class BulkTagInterface {
 		var numTags = this.tagSelections.numberOfTags;
 
 		if (numRefs > 0 && numTags > 0) {
-			console.log("go ahead...");
 			$("#bulkTaggingForm #referenceIds").val(this.commaDelim(this.referenceSelections.ids));
 			$("#bulkTaggingForm #tagIds").val(this.commaDelim(this.tagSelections.ids));
 
@@ -107,7 +104,6 @@ class BulkTagInterface {
 		var singleAlertShown = false;
 		$("input[type='checkbox']").each(function() {
 			if ($(this).prop("checked") != doCheck) {
-				console.log("now at [" + hook.referenceSelections.numberOfIds + "]...");
 				if (!doCheck || hook.referenceSelections.numberOfIds < hook.maxRefsPerBatch) {
 					$(this).prop("checked", doCheck).trigger("change");
 				} else {
@@ -156,7 +152,6 @@ class BulkTagInterface {
 		var referenceId = checkbox.attr("data-referenceId");
 		if (checkbox.prop("checked")) {
 			if (this.referenceSelections.numberOfIds < this.maxRefsPerBatch) {
-				console.log("checked [" + referenceId + "]");
 				if (this.referenceSelections.ids[referenceId] === undefined) {
 					this.referenceSelections.ids[referenceId] = true;
 					this.referenceSelections.numberOfIds++;
@@ -166,15 +161,12 @@ class BulkTagInterface {
 				this.showMaxWarning();
 			}
 		} else {
-			console.log("deselected [" + referenceId + "]");
 			if (this.referenceSelections.ids[referenceId] !== undefined) {
 				delete this.referenceSelections.ids[referenceId];
 				this.referenceSelections.numberOfIds--;
 			}
 		}
 
-		console.log("NOW:");
-		console.log(this.referenceSelections);
 		this.updateTaglistTitle();
 	}
 
@@ -189,7 +181,6 @@ class BulkTagInterface {
 		} else {
 			this.setStatus("References " + startIdx + "-" + endIdx + " of " + totalIdx);
 		}
-		console.log(data);
 
 		var tbl = $("table#reference_list");
 		var headerRow = $("<tr/>").appendTo(tbl);
@@ -268,7 +259,6 @@ class BulkTagInterface {
 		if (this.sortOrder != "") {
 			testUrl += "&ordering=" + this.sortOrder;
 		}
-		console.log("test url is [" + testUrl + "]");
 
 		this.setLoading(true);
 

--- a/project/assets/lit/BulkTagInterface.js
+++ b/project/assets/lit/BulkTagInterface.js
@@ -1,0 +1,286 @@
+class BulkTagInterface {
+	maxRefsPerBatch = 500;
+
+	assessmentId = -1;
+	pageNum = 0;
+	pageSize = 50;
+	sortOrder = "-year";
+	referenceSelections = null;
+	tagSelections = null;
+
+	constructor(lit, assessmentId, tags) {
+		this.assessmentId = assessmentId;
+		this.referenceSelections = {
+			ids: {},
+			numberOfIds: 0
+		};
+
+		this.tagSelections = {
+			ids: {},
+			numberOfTags: 0
+		};
+
+		this.pageNum = 0;
+
+		var hook = this;
+		$("#listing_variety").change(function() {
+			hook.pageNum = 0;
+			hook.loadReferences();
+		});
+
+		var shortcutDiv = $("#shortcut_links");
+		$("<a/>").html("Check All Boxes On This Page").appendTo(shortcutDiv).click(function() { hook.checkAllBoxes(true); });
+		$("<span/>").html(" | ").appendTo(shortcutDiv);
+		$("<a/>").html("Uncheck All Boxes On This Page").appendTo(shortcutDiv).click(function() { hook.checkAllBoxes(false); });
+		$("<span/>").html(" | ").appendTo(shortcutDiv);
+		$("<a/>").html("Clear All Selected References").appendTo(shortcutDiv).click(function() {
+			if (hook.referenceSelections.numberOfIds > 0 && confirm('Are you sure you want to clear all selections?')) {
+				$("input[type='checkbox']").each(function() {
+					$(this).prop("checked", false);
+					hook.referenceSelections.ids = {};
+					hook.referenceSelections.numberOfIds = 0;
+				});
+
+				hook.updateTaglistTitle();
+			}
+		});
+
+		// add tagtree widget
+        window.tagtree = new lit.TagTree(tags);
+        $('#taglist').html(window.tagtree.get_nested_list({"show_refs_count": false}))
+            .on('hawc-tagClicked', function(e){
+                var clickedTag = $(e.target);
+                console.log("tag clicked");
+                var tagId = clickedTag.parent("div").attr("data-id");
+                  // $(e.target).addClass("selected");
+                if (clickedTag.hasClass("selected")) {
+                    clickedTag.removeClass("selected");
+					hook.tagSelections.numberOfTags--;
+					delete hook.tagSelections.ids[tagId];
+                } else {
+                    clickedTag.addClass("selected");
+					hook.tagSelections.numberOfTags++;
+					hook.tagSelections.ids[tagId] = true;
+                }
+
+				console.log(hook.tagSelections);
+				hook.updateTaglistTitle();
+            });
+
+		$("#submitBtn").click(function() {
+			hook.submitBulkOperation();
+		});
+ 
+
+		this.updateTaglistTitle();
+	}
+
+	commaDelim = function(obj) {
+		var rv = "";
+		for (var key in obj) {
+			rv += (rv == "" ? "" : ",") + key;
+		}
+		return rv;
+	}
+
+	submitBulkOperation = function() {
+		var numRefs = this.referenceSelections.numberOfIds;
+		var numTags = this.tagSelections.numberOfTags;
+
+		if (numRefs > 0 && numTags > 0) {
+			console.log("go ahead...");
+			$("#bulkTaggingForm #referenceIds").val(this.commaDelim(this.referenceSelections.ids));
+			$("#bulkTaggingForm #tagIds").val(this.commaDelim(this.tagSelections.ids));
+
+			$("#bulkTaggingForm").submit();
+		} else {
+			alert('You must select at least one reference and one tag to submit');
+		}
+	}
+
+	showMaxWarning = function() {
+		alert("You have selected the maximum of " + this.maxRefsPerBatch + " references.");
+	}
+
+	checkAllBoxes = function(doCheck) {
+		var hook = this;
+		var singleAlertShown = false;
+		$("input[type='checkbox']").each(function() {
+			if ($(this).prop("checked") != doCheck) {
+				console.log("now at [" + hook.referenceSelections.numberOfIds + "]...");
+				if (!doCheck || hook.referenceSelections.numberOfIds < hook.maxRefsPerBatch) {
+					$(this).prop("checked", doCheck).trigger("change");
+				} else {
+					if (doCheck && !singleAlertShown) {
+						setTimeout(function() {
+							hook.showMaxWarning();
+						}, 10);
+						singleAlertShown = true;
+					}
+				}
+			}
+		});
+	}
+
+	setLoading = function(doClear) {
+		if (doClear) {
+			$("table#reference_list").empty();
+		}
+		this.setStatus("Loading...");
+	}
+
+	setStatus = function(s) {
+		$("div#status_msg").html(s);
+	}
+
+	updateTaglistTitle = function() {
+		var numRefs = this.referenceSelections.numberOfIds;
+		var numTags = this.tagSelections.numberOfTags;
+		var submitBtn = $("#submitBtn");
+		submitBtn.html("Apply " + numTags + " selected tag" +
+								(numTags == 1 ? "" : "s") +
+								" to " + numRefs + 
+								" reference" + (numRefs == 1 ? "" : "s") +
+								" (maximum of " + this.maxRefsPerBatch + ")");
+
+		submitBtn.parent("div.span3").css("width", "100%");
+
+		if (numRefs > 0 && numTags > 0) {
+			submitBtn.removeClass("disabled");
+		} else {
+			submitBtn.addClass("disabled");
+		}
+	};
+	
+	onCheckboxModified = function(checkbox) {
+		var referenceId = checkbox.attr("data-referenceId");
+		if (checkbox.prop("checked")) {
+			if (this.referenceSelections.numberOfIds < this.maxRefsPerBatch) {
+				console.log("checked [" + referenceId + "]");
+				if (this.referenceSelections.ids[referenceId] === undefined) {
+					this.referenceSelections.ids[referenceId] = true;
+					this.referenceSelections.numberOfIds++;
+				}
+			} else {
+				checkbox.prop("checked", false);
+				this.showMaxWarning();
+			}
+		} else {
+			console.log("deselected [" + referenceId + "]");
+			if (this.referenceSelections.ids[referenceId] !== undefined) {
+				delete this.referenceSelections.ids[referenceId];
+				this.referenceSelections.numberOfIds--;
+			}
+		}
+
+		console.log("NOW:");
+		console.log(this.referenceSelections);
+		this.updateTaglistTitle();
+	}
+
+	populateTable = function(data) {
+		var hook = this;
+		var startIdx = (this.pageNum * this.pageSize) + 1;
+		var endIdx = startIdx + data.results.length - 1;
+		var totalIdx = data.count;
+
+		if (totalIdx == 0) {
+			this.setStatus("No References Found");
+		} else {
+			this.setStatus("References " + startIdx + "-" + endIdx + " of " + totalIdx);
+		}
+		console.log(data);
+
+		var tbl = $("table#reference_list");
+		var headerRow = $("<tr/>").appendTo(tbl);
+		var headers = [ "", "title", "authors", "year" ];
+		var widths = [ 5, 60, 25, 10 ];
+
+		var sortByHeader = function(header, prefix) {
+			hook.sortOrder = (prefix === undefined ? "" : prefix) + header;
+			hook.pageNum = 0;
+			hook.loadReferences();
+		};
+
+		for (var i = 0 ; i < headers.length ; i++) {
+			var header = headers[i];
+			var th = $("<th/>").addClass("sort-header").attr("data-sortkey", header).html(header).appendTo(headerRow);
+			th.css("width", widths[i] + "%");
+
+			if (header == this.sortOrder) {
+				th.addClass("sort-down");
+				th.click(function() { sortByHeader($(this).attr("data-sortkey"), "-"); });
+			} else if ("-" + header == this.sortOrder) {
+				th.addClass("sort-up");
+				th.click(function() { sortByHeader($(this).attr("data-sortkey")); });
+			} else {
+				th.click(function() { sortByHeader($(this).attr("data-sortkey")); });
+			}
+		}
+
+		for (var i = 0 ; i < data.results.length ; i++) {
+			var ref = data.results[i];
+			var row = $("<tr/>").appendTo(tbl);
+			var td = $("<td/>").appendTo(row);
+
+			var cb = $("<input/>").attr("type", "checkbox").attr("data-referenceId", ref.id).appendTo(td).change(function() {
+				hook.onCheckboxModified($(this));
+			});
+
+			if (this.referenceSelections.ids[ref.id] !== undefined) {
+				cb.prop("checked", true);
+			}
+
+			$("<td/>").html(ref.title + " (" + ref.id + ")").appendTo(row);
+			$("<td/>").html(ref.authors).appendTo(row);
+			$("<td/>").html(ref.year).appendTo(row);
+		}
+
+		var paginationDiv = $("div#pagination_links").empty();
+		if (data.previous != null) {
+			$("<a/>").html("Previous").click(function() {
+				hook.pageNum -= 1;
+				hook.loadReferences();
+			}).appendTo(paginationDiv);
+		}
+
+		if (data.next != null) {
+			if (data.previous != null) {
+				$("<span/>").html(" | ").appendTo(paginationDiv);
+			}
+
+			$("<a/>").html("Next").click(function() {
+				hook.pageNum += 1;
+				hook.loadReferences();
+			}).appendTo(paginationDiv);
+		}
+
+	}
+
+	loadReferences = function() {
+		// http://localhost:8000/lit/api/reference/?assessment_id=483&limit=25&ordering=title&listing_variety=untagged_onlyx
+		var testUrl = "/lit/api/reference/?assessment_id=" +
+						this.assessmentId +
+						"&limit=" + this.pageSize + 
+						"&offset=" + (this.pageNum * this.pageSize) +
+						"&listing_variety=" + $("#listing_variety").val();
+
+		if (this.sortOrder != "") {
+			testUrl += "&ordering=" + this.sortOrder;
+		}
+		console.log("test url is [" + testUrl + "]");
+
+		this.setLoading(true);
+
+		var hook = this;
+		$.get(testUrl, function (data, success) {
+			if (success) {
+				hook.populateTable(data);
+			} else {
+				hook.setStatus("An error occurred.");
+			}
+		});
+	}
+};
+
+export default BulkTagInterface;

--- a/project/assets/lit/index.js
+++ b/project/assets/lit/index.js
@@ -4,6 +4,7 @@ import ReferencesViewer from './ReferencesViewer';
 import TagTree from './TagTree';
 import TagTreeViz from './TagTreeViz';
 import startupSearchReference from './startupSearchReference';
+import BulkTagInterface from './BulkTagInterface';
 
 
 export default {
@@ -13,4 +14,5 @@ export default {
     TagTree,
     TagTreeViz,
     startupSearchReference,
+	BulkTagInterface,
 };

--- a/project/lit/api.py
+++ b/project/lit/api.py
@@ -25,6 +25,7 @@ class ReferenceCleanup(CleanupFieldsBaseViewSet):
 
 class Reference(viewsets.ReadOnlyModelViewSet):
     assessment_filter_args = "assessment"
+    serializer_class = serializers.ReferenceBasicFieldsSerializer
     model = models.Reference
     pagination_class = LimitOffsetPagination
     permission_classes = (AssessmentLevelPermissions, )
@@ -53,8 +54,5 @@ class Reference(viewsets.ReadOnlyModelViewSet):
                     qs = qs.filter(number_of_tags__gt = 0)
 
             return qs
-
-    def get_serializer_class(self):
-        cls = serializers.ReferenceBasicFieldsSerializer
-        return cls
-
+        else:
+            return self.model.objects.all()

--- a/project/lit/api.py
+++ b/project/lit/api.py
@@ -1,4 +1,12 @@
-from assessment.api import AssessmentRootedTagTreeViewset
+from rest_framework import filters
+from rest_framework import viewsets
+from rest_framework.pagination import LimitOffsetPagination
+
+from django.db.models import Count
+
+from assessment.api import (
+    AssessmentLevelPermissions, InAssessmentFilter, AssessmentRootedTagTreeViewset
+)
 
 from . import models, serializers
 
@@ -14,3 +22,39 @@ class ReferenceCleanup(CleanupFieldsBaseViewSet):
     serializer_class = serializers.ReferenceCleanupFieldsSerializer
     model = models.Reference
     assessment_filter_args = "assessment"
+
+class Reference(viewsets.ReadOnlyModelViewSet):
+    assessment_filter_args = "assessment"
+    model = models.Reference
+    pagination_class = LimitOffsetPagination
+    permission_classes = (AssessmentLevelPermissions, )
+    filter_backends = (InAssessmentFilter, filters.DjangoFilterBackend, filters.OrderingFilter)
+    ordering_fields = ['year', 'title', 'authors']
+
+    def get_queryset(self):
+        if self.action == "list":
+            qs = None
+            if not self.assessment.user_can_edit_object(self.request.user):
+                qs = self.model.objects.published(self.assessment)
+            else:
+                qs = self.model.objects.get_qs(self.assessment)
+
+            # users can specify "tagged_only", "untagged_only", or anything else by passing in an optional "listing_variety" queryparam.
+            # by default we'll return everything, but we can optionally annotate the query and 
+            # then filter against that "number_of_tags" to return just the asked for variety
+            listing_variety = self.request.query_params.get('listing_variety')
+
+            if listing_variety == "tagged_only" or listing_variety == "untagged_only":
+                qs = qs.annotate(number_of_tags = Count('tags'))
+
+                if listing_variety == "untagged_only":
+                    qs = qs.filter(number_of_tags = 0)
+                elif listing_variety == "tagged_only":
+                    qs = qs.filter(number_of_tags__gt = 0)
+
+            return qs
+
+    def get_serializer_class(self):
+        cls = serializers.ReferenceBasicFieldsSerializer
+        return cls
+

--- a/project/lit/models.py
+++ b/project/lit/models.py
@@ -622,6 +622,12 @@ class Reference(models.Model):
         help_text="Used internally for determining when reference was "
                   "originally added")
 
+    @property
+    def has_tags(self):
+        for t in self.tags.all():
+            return True
+        return False
+
     def get_absolute_url(self):
         return reverse('lit:ref_detail', kwargs={'pk': self.pk})
 

--- a/project/lit/serializers.py
+++ b/project/lit/serializers.py
@@ -52,19 +52,10 @@ class ReferenceBasicFieldsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Reference
-        # fields = '__all__'
         fields = ['id', 'title', 'authors', 'year', 'tags', 'has_tags']
 
     def get_tags(self, obj):
-        tags = []
-        for t in obj.tags.all():
-            tag = {
-                "id": t.pk,
-                "name": t.name
-            }
-            tags.append(tag)
-
-        return tags
+        return list(obj.tags.all().values('id', 'name'))
 
     def get_has_tags(self, obj):
         return obj.has_tags

--- a/project/lit/serializers.py
+++ b/project/lit/serializers.py
@@ -45,3 +45,26 @@ class ReferenceCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSeri
         model = models.Reference
         cleanup_fields = model.TEXT_CLEANUP_FIELDS
         fields = cleanup_fields + ('id', )
+
+class ReferenceBasicFieldsSerializer(serializers.ModelSerializer):
+    tags = serializers.SerializerMethodField()
+    has_tags = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.Reference
+        # fields = '__all__'
+        fields = ['id', 'title', 'authors', 'year', 'tags', 'has_tags']
+
+    def get_tags(self, obj):
+        tags = []
+        for t in obj.tags.all():
+            tag = {
+                "id": t.pk,
+                "name": t.name
+            }
+            tags.append(tag)
+
+        return tags
+
+    def get_has_tags(self, obj):
+        return obj.has_tags

--- a/project/lit/urls.py
+++ b/project/lit/urls.py
@@ -115,7 +115,7 @@ urlpatterns = [
         views.RISExportInstructions.as_view(),
         name='ris_export_instructions'),
 
-    url(r'^assessment/(?P<pk>\d+)/bulk-tagging$',
+    url(r'^assessment/(?P<pk>\d+)/bulk-tagging/$',
         views.BulkTagging.as_view(),
         name='bulk_tagging'),
 

--- a/project/lit/urls.py
+++ b/project/lit/urls.py
@@ -6,6 +6,7 @@ from . import views, api
 
 
 router = DefaultRouter()
+router.register(r'reference', api.Reference, base_name="reference")
 router.register(r'tags', api.ReferenceFilterTag, base_name="tags")
 router.register(r'reference-cleanup', api.ReferenceCleanup, base_name="reference-cleanup")
 
@@ -113,6 +114,10 @@ urlpatterns = [
     url(r'^ris-export-instructions/$',
         views.RISExportInstructions.as_view(),
         name='ris_export_instructions'),
+
+    url(r'^assessment/(?P<pk>\d+)/bulk-tagging$',
+        views.BulkTagging.as_view(),
+        name='bulk_tagging'),
 
     url(r'^api/', include(router.urls, namespace='api')),
 ]

--- a/project/lit/views.py
+++ b/project/lit/views.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 
 from django.core.urlresolvers import reverse_lazy
+from django.db.transaction import atomic
 from django.forms.models import model_to_dict
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.shortcuts import get_object_or_404
@@ -38,6 +39,49 @@ class LitOverview(BaseList):
         context['tags'] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
         return context
 
+class BulkTagging(TemplateView):
+    template_name = "lit/bulk_tagging.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        self.assessment = get_object_or_404(Assessment, pk=kwargs['pk'])
+        context['assessment'] = self.assessment
+        context['tags'] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
+        context['method'] = 'GET'
+        return context
+
+    def post(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)
+        context['method'] = 'POST'
+
+        ref_ids = (self.request.POST["referenceIds"]).split(",")
+        tag_ids = (self.request.POST["tagIds"]).split(",")
+
+        self.process_bulk_tag_request(ref_ids, tag_ids)
+
+        return super(TemplateView, self).render_to_response(context)
+
+    @atomic
+    def process_bulk_tag_request(self, reference_ids_strings, tag_ids_strings):
+        tag_ids = [ tryParseInt(tag_id, -1) for tag_id in tag_ids_strings ]
+        ref_ids = [ tryParseInt(ref_id, -1) for ref_id in reference_ids_strings ]
+
+        existing = models.ReferenceTags.objects.filter(tag__in=tag_ids, content_object__in=ref_ids)
+        existing_set = {f'{tag.tag_id}-{tag.content_object_id}' for tag in existing}
+
+        creates = []
+        ref_ids_to_update = set()
+        for tag in tag_ids:
+            for ref in ref_ids:
+                if f'{tag}-{ref}' not in existing_set:
+                    creates.append(models.ReferenceTags(tag_id=tag, content_object_id=ref))
+                    ref_ids_to_update.add(ref)
+
+        models.ReferenceTags.objects.bulk_create(creates)
+
+        models.Reference.objects.filter(pk__in=ref_ids_to_update).update(last_updated=datetime.now())
+
+        # note from Andy - necessary to somehow clear lit cache after bulk create?
 
 class SearchList(BaseList):
     parent_model = Assessment

--- a/project/static/css/hawc.css
+++ b/project/static/css/hawc.css
@@ -540,3 +540,18 @@ Risk of Bias
 table.bordered th, table.bordered td {
 	border: 1px solid #dddddd;
 }
+
+/* bulk tagging - start */
+form#bulkTaggingForm table {
+	border: 1px solid #eeeeee;
+	margin: 10px;
+}
+
+form#bulkTaggingForm td {
+	border: 1px solid #eeeeee;
+}
+
+form#bulkTaggingForm a {
+	cursor: pointer;
+}
+/* bulk tagging - end */

--- a/project/templates/lit/bulk_tagging.html
+++ b/project/templates/lit/bulk_tagging.html
@@ -1,0 +1,122 @@
+{% extends 'portal.html' %}
+
+{% block title %}
+  {{assessment}} | Literature Review | HAWC
+{% endblock %}
+
+{% block breadcrumbs %}
+  <li><a href="{% url 'assessment:detail' pk=assessment.pk %}">{{ assessment }}</a><span class="divider">/</span></li>
+  <li><a href="{% url 'lit:overview' assessment.pk %}">Literature Review</a><span class="divider">/</span></li>
+  <li class="active">Bulk Reference Tagging<span class="divider">/</span></li>
+{% endblock %}
+
+{% block content %}
+
+<h2>Bulk Reference Tagging for {{assessment}}</h2>
+
+{% if method == "GET" %}
+
+<form method="POST" id="bulkTaggingForm">
+	{% csrf_token %}
+	References to fetch: <select id="listing_variety">
+							<option value="untagged_only">Untagged Only</option>
+							<option value="tagged_only">Tagged Only</option>
+							<option value="all">All</option>
+						</select>
+	<input type="hidden" id="referenceIds" name="referenceIds"/>
+	<input type="hidden" id="tagIds" name="tagIds"/>
+	<p>
+	<div id="status_msg"></div>
+	<table id="reference_list">
+	</table>
+	<div id="shortcut_links"></div>
+	<div id="pagination_links"></div>
+
+	<hr>
+
+    <div class="span3">
+      <div id="taglist"></div><br>
+      <a class="btn btn-primary" id="submitBtn"></a>
+    </div>
+
+</form>
+
+{% else %}
+
+Your bulk tag operation has been completed. <a href="{% url 'lit:bulk_tagging' assessment.pk %}">Make another</a>?
+
+{% endif %}
+
+
+{% endblock %}
+
+{% block extrajs %}
+  <script type="text/javascript">
+    window.app.litStartup(function(lit){
+		let bti = new lit.BulkTagInterface(lit, {{ assessment.pk }}, {{ tags|safe }});
+		bti.loadReferences();
+
+		console.log("TAGS: ");
+		console.log({{ tags|safe}});
+
+		/*
+		// build a standard tagtree...
+        window.tagtree = new lit.TagTree({{tags|safe}});
+		$('#taglist').html(window.tagtree.get_nested_list({"show_refs_count": false}))
+			.on('hawc-tagClicked', function(e){
+				var clickedTag = $(e.target);
+				// console.log("tag clicked");
+				// console.log(e);
+				  // $(e.target).addClass("selected");
+				if (clickedTag.hasClass("selected")) {
+					clickedTag.removeClass("selected");
+				} else {
+					clickedTag.addClass("selected");
+				}
+			});
+		*/
+
+		// and now muck with it - add some checkboxes and disable the ability to collapse the tree
+		/*
+		$("div#taglist").find("div").each(function() {
+			if ($(this).attr("data-id") != undefined) {
+				$("<input/>").attr("type", "checkbox").prependTo($(this)).css({
+					"position": "absolute",
+					"margin-left": "-10px",
+					"margin-top": "7px"
+				});
+			}
+		});
+		$("div.collapse").css("overflow", "visible");
+		$("span.nestedTagCollapser").remove();
+		*/
+
+		/*
+		window.ref_container = new lit.EditReferenceContainer([], window.tagtree,
+												{"content_div": "#foobar"});
+												*/
+
+
+		/*
+		  $('#taglist')
+			.html(tagtree.get_nested_list({"show_refs_count": true}))
+			.on('hawc-tagClicked', function(e){
+			  $('.nestedTag').removeClass("selected");
+			  $(e.target).addClass("selected");
+			  var tag = $(e.target).data('d'),
+				  options = {
+					tag: tag,
+					download_url: "{% url 'lit:ref_download_excel' assessment.pk %}"
+				  },
+				  refviewer = new lit.ReferencesViewer($('#references_detail_div'), options);
+			  tag.get_reference_objects_by_tag(refviewer);
+			});
+		*/
+
+    // let refviewer = new lit.ReferencesViewer($('#referenceTbl'), {fixed_title: 'Search Results'});
+      // window.tagtree = new lit.TagTree({{tags|safe}});
+      // $('#tags').html(window.tagtree.get_nested_list({"show_refs_count": false}))
+    });
+  </script>
+{% endblock extrajs %}
+

--- a/project/templates/lit/bulk_tagging.html
+++ b/project/templates/lit/bulk_tagging.html
@@ -55,67 +55,6 @@ Your bulk tag operation has been completed. <a href="{% url 'lit:bulk_tagging' a
     window.app.litStartup(function(lit){
 		let bti = new lit.BulkTagInterface(lit, {{ assessment.pk }}, {{ tags|safe }});
 		bti.loadReferences();
-
-		console.log("TAGS: ");
-		console.log({{ tags|safe}});
-
-		/*
-		// build a standard tagtree...
-        window.tagtree = new lit.TagTree({{tags|safe}});
-		$('#taglist').html(window.tagtree.get_nested_list({"show_refs_count": false}))
-			.on('hawc-tagClicked', function(e){
-				var clickedTag = $(e.target);
-				// console.log("tag clicked");
-				// console.log(e);
-				  // $(e.target).addClass("selected");
-				if (clickedTag.hasClass("selected")) {
-					clickedTag.removeClass("selected");
-				} else {
-					clickedTag.addClass("selected");
-				}
-			});
-		*/
-
-		// and now muck with it - add some checkboxes and disable the ability to collapse the tree
-		/*
-		$("div#taglist").find("div").each(function() {
-			if ($(this).attr("data-id") != undefined) {
-				$("<input/>").attr("type", "checkbox").prependTo($(this)).css({
-					"position": "absolute",
-					"margin-left": "-10px",
-					"margin-top": "7px"
-				});
-			}
-		});
-		$("div.collapse").css("overflow", "visible");
-		$("span.nestedTagCollapser").remove();
-		*/
-
-		/*
-		window.ref_container = new lit.EditReferenceContainer([], window.tagtree,
-												{"content_div": "#foobar"});
-												*/
-
-
-		/*
-		  $('#taglist')
-			.html(tagtree.get_nested_list({"show_refs_count": true}))
-			.on('hawc-tagClicked', function(e){
-			  $('.nestedTag').removeClass("selected");
-			  $(e.target).addClass("selected");
-			  var tag = $(e.target).data('d'),
-				  options = {
-					tag: tag,
-					download_url: "{% url 'lit:ref_download_excel' assessment.pk %}"
-				  },
-				  refviewer = new lit.ReferencesViewer($('#references_detail_div'), options);
-			  tag.get_reference_objects_by_tag(refviewer);
-			});
-		*/
-
-    // let refviewer = new lit.ReferencesViewer($('#referenceTbl'), {fixed_title: 'Search Results'});
-      // window.tagtree = new lit.TagTree({{tags|safe}});
-      // $('#tags').html(window.tagtree.get_nested_list({"show_refs_count": false}))
     });
   </script>
 {% endblock extrajs %}

--- a/project/templates/lit/overview.html
+++ b/project/templates/lit/overview.html
@@ -27,6 +27,7 @@
           <li><a href="{% url 'study:new_ref' assessment.pk %}">Add new reference (manually)</a></li>
           <li><a href="{% url 'lit:search_tags_edit' assessment.pk manual_import.slug %}">Tag manually-added references</a></li>
           <li><a href="{% url 'lit:tag_untagged' assessment.pk %}">Tag untagged references</a></li>
+          <li><a href="{% url 'lit:bulk_tagging' assessment.pk %}">Bulk reference tagging</a></li>
           {% if obj_perms.edit_assessment %}
             <li class="disabled"><a tabindex="-1" href="#">Assessment-level editing</a></li>
             <li><a href="{% url 'lit:tags_update' assessment.pk %}">Update literature tags</a></li>


### PR DESCRIPTION
addresses https://trello.com/c/dxz8bbp7/96-tagging-multiple-references-at-a-time-high by adding a bulk tagging tool, accessible via the "Actions" dropdown on the Literature Review module.

Capped at 500 references at a time; edit BulkTagInterface.js to change that.

Speed seems ok even on my dev machine just doing bulk saves as recommended; if seems too pokey to you I can look into moving this into Celery.